### PR TITLE
Show number of files currently displayed in gallery

### DIFF
--- a/src/frontend/containers/AppToolbar/PrimaryCommands.tsx
+++ b/src/frontend/containers/AppToolbar/PrimaryCommands.tsx
@@ -97,7 +97,7 @@ const FileSelectionCommand = observer(() => {
       icon={allFilesSelected ? IconSet.SELECT_ALL_CHECKED : IconSet.SELECT_ALL}
       onClick={handleToggleSelect}
       pressed={allFilesSelected}
-      text={selectionCount}
+      text={fileCount == 0 ? "0" : selectionCount +" / "+ fileCount}
       tooltip="Selects or deselects all images"
       disabled={fileCount === 0}
     />


### PR DESCRIPTION
Add info in the toolbar:
`selected files / files in current gallery`

![Allusion_oWPkoL7y5x](https://github.com/user-attachments/assets/57b66f21-23f6-4896-92ff-0d00ca255f1f)
