### PR TITLE
Tweak css

### DIFF
--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -500,20 +500,19 @@
       justify-content: space-between;
       column-gap: 0.25em;
 
-      background-color: rgba(0, 0, 0, 0.5);
-      color: rgb(
-        200,
-        200,
-        200
-      ); // can't use --text-color: black text on black background in light theme
+      background-color: rgba(0, 0, 0, 0);
+      color: hsl(0deg 0% 85%); // can't use --text-color: black text on black background in light theme
+      text-shadow: // fake black outline around font
+       -1px -1px 1px black, 0px -1px 1px black, 1px -1px 1px black,
+       -1px  0px 1px black, 0px  0px 1px black, 1px  0px 1px black,
+       -1px  1px 1px black, 0px  1px 1px black, 1px  1px 1px black;
       width: 100%;
-      height: 1.5em;
+      height: 1.6em;
       position: absolute;
       bottom: 0;
       padding: 0.25rem;
 
-      opacity: 0.75;
-      transition: opacity 0.25s $pt-transition-cubic2, background-color 0.25s $pt-transition-cubic2;
+      transition: background-color 0.25s $pt-transition-cubic2;
 
       // Resolution is always visible if enabled by truncating the filename
       > :first-child {
@@ -523,14 +522,13 @@
         
         // Only here to avoid vertical scrollbar due to overflow-x: hidden
         // It won't take up more than 1 line due to no-wrap
-        height: 2em; 
+        height: 2em;
       }
     }
 
     &:hover {
       .thumbnail-overlay {
-        opacity: 1;
-        background-color: rgba(0, 0, 0, 0.75);
+        background-color: rgba(0, 0, 0, .75);
 
         &:hover {
           // Expand filename on hover if it was truncated

--- a/resources/style/content.scss
+++ b/resources/style/content.scss
@@ -48,13 +48,13 @@
   -webkit-user-drag: element;
   background-color: var(--background-color-alt);
   border: 0.0625rem solid var(--border-color);
-  border-radius: 0.25rem;
+  border-radius: var(--thumbnail-radius);
 
   transition: background-color 0.2s $pt-transition-cubic2;
 
   // This acts as the border-radius, but also for child elements
   :first-child {
-    clip-path: inset(0 round 0.125rem);
+    clip-path: inset(0 round var(--thumbnail-radius));
     transition: clip-path 0.2s $pt-transition-cubic2;
     pointer-events: none;
   }
@@ -66,14 +66,14 @@
     margin-left: auto;
     margin-right: auto;
     display: block;
-    border-radius: 0.25rem;
+    border-radius: var(--thumbnail-radius);
   }
 
   &[data-dnd-target='true'] {
     background-color: var(--accent-color-yellow);
 
     :is(img, video) {
-      clip-path: inset(0.5rem round 0.125rem);
+      clip-path: inset(0.25rem round calc(var(--thumbnail-radius) - 0.25rem));
     }
   }
 }
@@ -82,7 +82,7 @@
   // If selected, show a blue border
   background-color: var(--accent-color);
   > :is(img, video) {
-    clip-path: inset(0.25rem round 0.125rem); // old design
+    clip-path: inset(0.25rem round calc(var(--thumbnail-radius) - 0.25rem)); // old design
   }
 
   // If selected AND drop target: big yellow border
@@ -90,7 +90,7 @@
     background-color: var(--accent-color-yellow);
     > :is(img, video),
     > .image-error {
-      clip-path: inset(0.5rem round 0.125rem);
+      clip-path: inset(0.5rem round calc(var(--thumbnail-radius) - 0.5rem));
     }
   }
 

--- a/resources/style/layout.scss
+++ b/resources/style/layout.scss
@@ -17,7 +17,7 @@ body {
 // Global specific styles for the main window
 #app {
   --mac-system-buttons-width: 5rem;
-  --window-titlebar-height: 28px;
+  --window-titlebar-height: 24px;
   --treeitem-identation: 0.5rem;
   --treeitem-offset: 0.75rem;
 }

--- a/resources/style/tag-editor.scss
+++ b/resources/style/tag-editor.scss
@@ -9,7 +9,7 @@
 #tag-editor {
   height: 14rem;
   min-height: 10rem;
-  max-height: 32rem;
+  max-height: calc(100vh - var(--toolbar-height) - 5rem);
   display: flex;
   flex-direction: column;
   overflow: auto;
@@ -17,12 +17,8 @@
 
   // Intended layout behavior:
   // - Input element has a static height
-  // - The tag checklist grows to fit the available space, until a max-height is reached
-  // - The applied tags section has a static height of 1.5 rows of tags,
-  //   and grows when the tag check-list has reached max-height
-  //   TODO: preferably: this section first fits to its content up to 3.5 rows (so only 1 row if there is 1 row of tags)
-  //   could figure out the CSS: we need something like min-height: calc(max(1.5rem, min(fit-content, 3.5rem)))
-  //   maybe with the fit-content() property coming soon? https://developer.mozilla.org/en-US/docs/Web/CSS/min-height#:~:text=5.0-,fit%2Dcontent(),-Experimental
+  // - The tag checklist expands or shrinks to fill available space
+  // - The applied tags section fits its content up to 3.5 rows of tags
 
   > input {
     margin: 0.5rem;
@@ -33,10 +29,11 @@
 
   // Checklist of all available tags
   [role='grid'] {
-    flex: 0 1 calc(16rem + 1px); // expand to fill available space, don't shrink unless absolutaly necessary
+    flex: 1 1 auto;
     border-top: 0.0625rem solid var(--border-color);
     border-bottom: 0.0625rem solid var(--border-color);
     max-width: unset;
+    max-height: unset;
 
     [role='separator'] {
       background: var(--text-color-muted);
@@ -47,11 +44,10 @@
 
   // The tags applied to the selected images
   > div:last-child {
-    flex: 1 1 auto; // shrink to make room for other elements, but grow if there is space available (other other elements reached their max height)
+    flex: 0 0 auto;
     margin: 0.5rem;
-    height: 3.375rem;
-    min-height: 2.375rem;
-    // preferably: min-height calc(max(min(3.75rem, fit-content), 1.375rem)), but doesn't work
+    min-height: 1.5rem; // 1 row of tags
+    max-height: calc(1.5rem * 3.5); // 3.5 rows of tags
     overflow: auto;
     display: flex;
     flex-wrap: wrap;

--- a/resources/style/themes.scss
+++ b/resources/style/themes.scss
@@ -71,4 +71,6 @@
 
   color: var(--text-color);
   background: var(--background-color);
+
+  --thumbnail-radius: 0.25rem;
 }


### PR DESCRIPTION
I tackled simple changes from my wishlist, to get familiar with the layout.
- expand the tag popup (shortcut T) to display a list of more than 6 tags without having to scroll
- move the border-radius amount in the theme, so you can now remove it (0rem) or make your pictures round AF (5rem or more!). Default is (and was) 0.25rem
- Shrink titlebar by 4px. Vertical pixels worth a lot!
- Show filename background only on hover. To help readability, I put a black outline on it.

![explorer_TjUrZyffh6](https://github.com/user-attachments/assets/e6abfbb8-98a5-4183-b494-8728bdb2aedc)
